### PR TITLE
Chomping the output of metric plugins to avoid sending empty newlines to

### DIFF
--- a/lib/sensu/extensions/mutators/metrics.rb
+++ b/lib/sensu/extensions/mutators/metrics.rb
@@ -81,7 +81,7 @@ module Sensu::Extension
     def mutate(mutator, ep_name)
       logger.debug("metrics.run mutating for #{ep_name.inspect}")
       check = @event[:check]
-      output = check[:output]
+      output = check[:output].chomp
       output_type = check[:output_type]
       endpoint_name = ep_name.to_s
 


### PR DESCRIPTION
carbon-relay/graphite, which logs an error every time that happens...
